### PR TITLE
Don't hardcode the config sync directory

### DIFF
--- a/hooks/common/post-code-deploy/post-deployment.sh
+++ b/hooks/common/post-code-deploy/post-deployment.sh
@@ -17,7 +17,7 @@ echo "Clear cache"
 drush10 @$drush_alias cr
 
 echo "Import config"
-drush10 @$drush_alias cim --source=../config/sync -y
+drush10 @$drush_alias cim -y
 
 echo "Update modules"
 drush10 @$drush_alias updb -y


### PR DESCRIPTION
This causes an issue preventing the config from importing if the sync directory configured doesn't match the hardcoded one.